### PR TITLE
fix: minimum count too high that prevents passing step 3 in some cases

### DIFF
--- a/.github/workflows/3-copilot-edits.yml
+++ b/.github/workflows/3-copilot-edits.yml
@@ -91,7 +91,7 @@ jobs:
           # Check for participants info in app.js
           file="src/static/app.js"
           keyphrase='participant'
-          minimum_occurences=5
+          minimum_occurences=3
           found_occurences=$(grep -o "$keyphrase" "$file" | wc -l)
           if [ "$found_occurences" -lt "$minimum_occurences" ]; then
             checks=$(echo $checks | jq '.app_js.passed = false')
@@ -101,7 +101,7 @@ jobs:
           # Check for participants info in styles.css
           file="src/static/styles.css"
           keyphrase='participant'
-          minimum_occurences=2
+          minimum_occurences=1
           found_occurences=$(grep -o "$keyphrase" "$file" | wc -l)
           if [ "$found_occurences" -lt "$minimum_occurences" ]; then
             checks=$(echo $checks | jq '.styles_css.passed = false')


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/3-copilot-edits.yml` file to update the minimum occurrences required for keyphrases in specific files.

Key changes:

* Reduced the `minimum_occurences` for the keyphrase 'participant' in `src/static/app.js` from 5 to 3.
* Reduced the `minimum_occurences` for the keyphrase 'participant' in `src/static/styles.css` from 2 to 1.