### PR TITLE
docs: use keyboard commands for inline chat

### DIFF
--- a/.github/steps/1-preparing.md
+++ b/.github/steps/1-preparing.md
@@ -85,7 +85,7 @@ Great work! Now that we are familiar with the app and we know it works, let's as
 
    > **Note:** This will avoid stopping the existing debug session that is hosting our web application service.
 
-1. Within the new terminal window, `right click` and select `Copilot` then `Terminal Inline Chat`. Alternately, you can use the keyboard shortcut `Ctrl + I` (windows) or `Cmd + I` (mac).
+1. Within the new terminal window use the keyboard shortcut `Ctrl + I` (windows) or `Cmd + I` (mac) to bring up **Copilot's Terminal Inline Chat**.
 
 1. Let's ask Copilot to help us remember a command we have forgotten: creating a branch and publishing it
 

--- a/.github/steps/2-first-introduction.md
+++ b/.github/steps/2-first-introduction.md
@@ -84,9 +84,9 @@ In new project developments, it's often helpful to have some realistic looking f
 
 1. Near the top (about line 23), find the `activities` variable, where our example extracurricular activies are configured.
 
-1. Open Copilot inline chat by right-clicking on any of the related lines and selecting **Copilot** and **Editor Inline Chat**.
+1. Click on any of the related lines and bring up Copilot inline chat by using the keyboard command `Ctrl + I` (windows) or `Cmd + I` (mac).
 
-   > **Tip:** You can also use the keyboard command `Ctrl + I` (windows) or `Cmd + I` (mac).
+   > **Tip:** Another way to bring up Copilot inline chat is: `right click` on any of the selected lines -> `Copilot` -> `Editor Inline Chat`.
 
 1. Enter the following prompt text and press enter or the **Send and Dispatch** button.
 


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Some browsers (firefox?) copy whatever is stored in the clipboard when you right click on the terminal. 

### Changes
<!-- Describe the changes this pull request introduces. -->

Change the step instructions to use keyboard shortcuts instead of right-clicking to avoid copying the terminal contents

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/15
Closes: https://github.com/skills/getting-started-with-github-copilot/issues/17

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
