### PR TITLE
refactor: replace find exercise job with reusable workflow

### DIFF
--- a/.github/workflows/1-preparing.yml
+++ b/.github/workflows/1-preparing.yml
@@ -15,32 +15,8 @@ env:
 
 jobs:
   find_exercise:
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url-by-title.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url-by-title
-        uses: actions/github-script@v7
-        env:
-          ISSUE_TITLE_PREFIX: "Exercise:"
-        with:
-          script: |
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 1
-            });
-
-            const issue = issues.data.find(issue => issue.title.includes(process.env.ISSUE_TITLE_PREFIX ));
-            if (!issue) {
-              throw new Error('No exercise issue found');
-            }
-
-            core.setOutput('ISSUE_URL', issue.html_url);
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/2-first-introduction.yml
+++ b/.github/workflows/2-first-introduction.yml
@@ -17,32 +17,8 @@ env:
 
 jobs:
   find_exercise:
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url-by-title.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url-by-title
-        uses: actions/github-script@v7
-        env:
-          ISSUE_TITLE_PREFIX: "Exercise:"
-        with:
-          script: |
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 1
-            });
-
-            const issue = issues.data.find(issue => issue.title.includes(process.env.ISSUE_TITLE_PREFIX ));
-            if (!issue) {
-              throw new Error('No exercise issue found');
-            }
-
-            core.setOutput('ISSUE_URL', issue.html_url);
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/3-copilot-edits.yml
+++ b/.github/workflows/3-copilot-edits.yml
@@ -17,32 +17,8 @@ env:
 
 jobs:
   find_exercise:
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url-by-title.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url-by-title
-        uses: actions/github-script@v7
-        env:
-          ISSUE_TITLE_PREFIX: "Exercise:"
-        with:
-          script: |
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 1
-            });
-
-            const issue = issues.data.find(issue => issue.title.includes(process.env.ISSUE_TITLE_PREFIX ));
-            if (!issue) {
-              throw new Error('No exercise issue found');
-            }
-
-            core.setOutput('ISSUE_URL', issue.html_url);
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   check_step_work:
     name: Check step work
@@ -108,7 +84,7 @@ jobs:
             checks=$(echo $checks | jq '.styles_css.message = "Please use Copilot to update the web application styling to support participant info."')
           fi
 
-          # Verify all checks passed 
+          # Verify all checks passed
           passed=$(echo $checks | jq '. | all(.passed?)')
 
           # Flatten to an array for returning. Allows iteration during rendering.

--- a/.github/workflows/3b-copilot-agent-mode.yml
+++ b/.github/workflows/3b-copilot-agent-mode.yml
@@ -35,27 +35,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
 
   find_exercise:
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url
-        run: |
-          # Get the issue url from the event or search for it.
-          if [ -n "${{ github.event.issue }}" ]; then
-            issue_url="${{ github.event.issue.html_url }}"
-          else
-            issue_url=$(gh issue list --repo $REPO --search "in:title Exercise:" --json url,title --jq '.[].url')
-          fi
-
-          # Save to output
-          echo "ISSUE_URL=$issue_url" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   post_step_3b_content:
     name: Post step 3b content

--- a/.github/workflows/4-copilot-on-github.yml
+++ b/.github/workflows/4-copilot-on-github.yml
@@ -17,29 +17,8 @@ env:
 
 jobs:
   find_exercise:
-    if: |
-      !github.event.repository.is_template
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url
-        run: |
-          # Get the issue url from the event or search for it.
-          if [ -n "${{ github.event.issue }}" ]; then
-            issue_url="${{ github.event.issue.html_url }}"
-          else
-            issue_url=$(gh issue list --repo $REPO --search "in:title Exercise:" --json url,title --jq '.[].url')
-          fi
-
-          # Save to output
-          echo "ISSUE_URL=$issue_url" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   check_step_work:
     name: Check step work

--- a/.github/workflows/4b-copilot-on-github.yml
+++ b/.github/workflows/4b-copilot-on-github.yml
@@ -20,29 +20,8 @@ permissions:
 
 jobs:
   find_exercise:
-    if: |
-      !github.event.repository.is_template
-    name: Find exercise by issue title
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.get-issue-url.outputs.ISSUE_URL }}
-
-    steps:
-      - id: get-issue-url
-        run: |
-          # Get the issue url from the event or search for it.
-          if [ -n "${{ github.event.issue }}" ]; then
-            issue_url="${{ github.event.issue.html_url }}"
-          else
-            issue_url=$(gh issue list --repo $REPO --search "in:title Exercise:" --json url,title --jq '.[].url')
-          fi
-
-          # Save to output
-          echo "ISSUE_URL=$issue_url" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+    name: Find Exercise Issue
+    uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.1.0
 
   check_step_work:
     name: Check step work
@@ -100,7 +79,7 @@ jobs:
               checks=$(echo $checks | jq '.copilot_review.message = "Please request a review from Copilot."')
           fi
 
-          # Verify all checks passed 
+          # Verify all checks passed
           passed=$(echo $checks | jq '. | all(.passed?)')
 
           # Flatten to an array for returning. Allows iteration during rendering.


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

The current workflow was checking for only 1 issue (the exercise issue)
```js
 const issues = await github.rest.issues.listForRepo({
        owner: context.repo.owner,
        repo: context.repo.repo,
        state: 'open',
        per_page: 1 <- HERE
      });
```

Which caused an issue when one of the users tried to open a bug report but opened the issue on their copy of the exercise repository.
![image](https://github.com/user-attachments/assets/a71a55b4-314e-4d7c-93ad-29197bf9d592)


### Changes
<!-- Describe the changes this pull request introduces. -->

Use the `find-exercise-issue` workflow from exercise-toolkit

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/18

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
