### PR TITLE
refactor: minimize main readme and use exercise toolkit for starting the exercise

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -11,133 +11,25 @@ permissions:
   issues: write
 
 env:
-  EXERCISE_NAME: "Getting Started with GitHub Copilot"
-  INTRO_MESSAGE: "Welcome to the exciting world of GitHub Copilot! 🚀 In this exercise, you'll unlock the potential of this AI-powered coding assistant to accelerate your development process. Let's dive in and have some fun exploring the future of coding together! 💻✨"
   STEP_1_FILE: ".github/steps/1-preparing.md"
 
 jobs:
-  disable_workflows:
-    name: Disable workflows
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Disable all workflows
-        run: |
-          workflows=$(git ls-files | grep -E '\.yml$|\.yaml$')
-          for workflow in $workflows; do
-            workflow_name=$(basename $workflow)
-            gh workflow disable "$workflow_name" || true
-          done
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   start_exercise:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    runs-on: ubuntu-latest
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@start-exercise-updates
+    with:
+      exercise-title: "Getting Started with GitHub Copilot"
+      intro-message: "Welcome to the exciting world of GitHub Copilot! 🚀 In this exercise, you'll unlock the potential of this AI-powered coding assistant to accelerate your development process. Let's dive in and have some fun exploring the future of coding together! 💻✨"
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure Git user
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-
-      - name: Deactivate 'Start Excercise' button
-        run: |
-          # Remove href from 'Start Exercise' button
-          target='id="copy-exercise"[^>]*href="[^"]*"'
-          replacement='id="copy-exercise"'
-          sed -i "s|$target|$replacement|g" README.md
-
-          # Change color from green to gray
-          target=Copy_Exercise-008000
-          replacement=Copy_Exercise-AAA
-          sed -i "s|$target|$replacement|g" README.md
-
-      - name: Activate 'Start Exercise' button
-        run: |
-          # Add link to issue
-          target='id="start-exercise"'
-          replacement='id="start-exercise" href="../../issues/1"'
-          sed -i "s|$target|$replacement|g" README.md
-
-          # Change color from gray to green
-          target=Start_Exercise-AAA
-          replacement=Start_Exercise-008000
-          sed -i "s|$target|$replacement|g" README.md
-
-      - name: Replace relative links in readme
-        run: |
-          target=../../
-          replacement=https://github.com/${{ github.repository }}/
-          sed -i "s|$target|$replacement|g" README.md
-
-      - name: Push README changes
-        run: |
-          git add README.md
-          git commit --message="Start exercise"
-          git push
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  create_exercise:
-    if: |
-      !github.event.repository.is_template
-    name: Create exercise issue
-    runs-on: ubuntu-latest
-
-    outputs:
-      issue-url: ${{ steps.create-issue.outputs.ISSUE_URL }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Get response templates
-        uses: actions/checkout@v4
-        with:
-          repository: skills/response-templates
-          path: skills-response-templates
-
-      - name: Configure Git user
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-
-      - name: Build welcome message from template
-        id: build-issue-description
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: skills-response-templates/step-feedback/welcome.md
-          template-vars: |
-            title=${{ env.EXERCISE_NAME }}
-            login=${{ github.actor }}
-            intro_message=${{ env.INTRO_MESSAGE }}
-
-      - name: Create issue - add welcome message
-        id: create-issue
-        run: |
-          issue_url=$(gh issue create \
-            --title "Exercise: $EXERCISE_NAME" \
-            --body "$ISSUE_BODY")
-          echo "ISSUE_URL=$issue_url" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-issue-description.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content
     runs-on: ubuntu-latest
-    needs: [create_exercise]
+    needs: [start_exercise]
     env:
-      ISSUE_URL: ${{ needs.create_exercise.outputs.issue-url }}
+      ISSUE_URL: ${{ needs.start_exercise.outputs.issue-url }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@start-exercise-updates
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.2.0
     with:
       exercise-title: "Getting Started with GitHub Copilot"
       intro-message: "Welcome to the exciting world of GitHub Copilot! 🚀 In this exercise, you'll unlock the potential of this AI-powered coding assistant to accelerate your development process. Let's dive in and have some fun exploring the future of coding together! 💻✨"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In this exercise, you will:
 
 Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
-   [![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public)
+[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public)
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>
@@ -41,10 +41,3 @@ If the exercise isn't ready in 20 seconds, please check the [Actions](../../acti
 - If the page shows a failed job, please submit an issue. Nice, you found a bug! 🐛
 
 </details>
-
-
----
-
-Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/getting-started-with-github-copilot) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
-
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Getting Started with GitHub Copilot
 
-![](../../actions/workflows/1-preparing.yml/badge.svg)
-![](../../actions/workflows/2-first-introduction.yml/badge.svg)
-![](../../actions/workflows/3-copilot-edits.yml/badge.svg)
-![](../../actions/workflows/4-copilot-on-github.yml/badge.svg)
-
 _Get started using GitHub Copilot in less than an hour._
 
 ## Welcome
@@ -28,9 +23,7 @@ In this exercise, you will:
 
 1. Right-click **Copy Exercise** and open the link in a new tab.
 
-   <a id="copy-exercise" href="https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public">
-      <img src="https://img.shields.io/badge/📠_Copy_Exercise-008000" height="25pt"/>
-   </a>
+   [![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public)
 
 2. In the new tab, most of the fields will automatically fill in for you.
 
@@ -38,20 +31,8 @@ In this exercise, you will:
    - We recommend creating a public repository, as private repositories will use [Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
    - Scroll down and click the **Create repository** button at the bottom of the form.
 
-3. After your new repository is created, wait about 20 seconds for the exercise to be prepared and buttons updated. You will continue working from your copy of the exercise.
+3. Refresh your repository in about 10-20 seconds to see how to proceed as the README will get updated. The automation is already working to prepare the exercise.
 
-   - The **Copy Exercise** button will deactivate, changing to gray.
-   - The **Start Exercise** button will activate, changing to green.
-   - You will likely need to refresh the page.
-
-4. Click **Start Exercise**. Follow the step-by-step instructions and feedback will be provided as you progress.
-
-   <a id="start-exercise">
-      <img src="https://img.shields.io/badge/🚀_Start_Exercise-AAA" height="25pt"/>
-   </a>
-
-> [!IMPORTANT]
-> The **Start Exercise** button will activate after copying the repository. You will probably need to refresh the page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,26 @@ In this exercise, you will:
 
 ### How to start this exercise
 
-1. Right-click **Copy Exercise** and open the link in a new tab.
+Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
    [![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-brightgreen?style=for-the-badge&logo=github)](https://github.com/new?template_owner=skills&template_name=getting-started-with-github-copilot&owner=%40me&name=skills-getting-started-with-github-copilot&description=Exercise:+Get+started+using+GitHub+Copilot&visibility=public)
 
-2. In the new tab, most of the fields will automatically fill in for you.
+<details>
+<summary>Having trouble? 🤷</summary><br/>
 
-   - For owner, choose your personal account or an organization to host the repository.
-   - We recommend creating a public repository, as private repositories will use [Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
-   - Scroll down and click the **Create repository** button at the bottom of the form.
+When copying the exercise, we recommend the following settings:
 
-3. Refresh your repository in about 10-20 seconds to see how to proceed as the README will get updated. The automation is already working to prepare the exercise.
+- For owner, choose your personal account or an organization to host the repository.
+
+- We recommend creating a public repository, since private repositories will use Actions minutes.
+   
+If the exercise isn't ready in 20 seconds, please check the [Actions](../../actions) tab.
+
+- Check to see if a job is running. Sometimes it simply takes a bit longer.
+
+- If the page shows a failed job, please submit an issue. Nice, you found a bug! 🐛
+
+</details>
 
 
 ---


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request simplifies and streamlines the workflow for starting an exercise by removing redundant steps and utilizing a shared workflow. Additionally, it involves updating README as the start-exercise workflow now generates the README from a template.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
