### PR TITLE
refactor: modify finish exercise workflow to overwrite README and use reusable workflow from exercise-toolkit

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
-    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.2.0
+    uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.3.0
     with:
       exercise-title: "Getting Started with GitHub Copilot"
       intro-message: "Welcome to the exciting world of GitHub Copilot! 🚀 In this exercise, you'll unlock the potential of this AI-powered coding assistant to accelerate your development process. Let's dive in and have some fun exploring the future of coding together! 💻✨"

--- a/.github/workflows/4-copilot-on-github.yml
+++ b/.github/workflows/4-copilot-on-github.yml
@@ -75,76 +75,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   finish_exercise:
-    name: Finish exercise
+    name: Finish Exercise
+    needs: [find_exercise, post_review_content]
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.3.0
+    with:
+      issue-url: ${{ needs.find_exercise.outputs.issue-url }}
+
+  disable_workflow:
+    name: Disable this workflow
     needs: [find_exercise, post_review_content]
     runs-on: ubuntu-latest
-    env:
-      ISSUE_URL: ${{ needs.find_exercise.outputs.issue-url }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Get response templates
-        uses: actions/checkout@v4
-        with:
-          repository: skills/response-templates
-          path: skills-response-templates
-
-      - name: Configure Git user
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-
-      - name: Build message - congratulations
-        id: build-message-congratulations
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: skills-response-templates/readme/congratulations.md
-          template-vars: |
-            login=${{ github.actor }}
-
-      - name: Update README - congratulations
-        run: |
-          # Add "Congratulations" to the start of the README
-          orig_readme=$(cat README.md)
-          new_readme="${{ steps.build-message-congratulations.outputs.updated-text }} $orig_readme"
-
-          # Update file and push
-          echo "$new_readme" > README.md
-          git add README.md
-          git commit --message="Congratulations!🎉"
-          git push
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build message - exercise finished
-        id: build-finish-message
-        uses: skills/action-text-variables@v1
-        with:
-          template-file: skills-response-templates/step-feedback/lesson-finished.md
-          template-vars: |
-            login=${{ github.actor }}
-            repo_full_name=${{ github.repository }}
-
-      - name: Create comment - exercise finished
-        run: |
-          gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-finish-message.outputs.updated-text }}
-
-      - name: Close issue
-        run: gh issue close "$ISSUE_URL"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Disable current workflow
-        run: |
-          gh workflow disable "Step 4"
-          gh workflow disable "Step 4b"
+        run: gh workflow disable "${{github.workflow}}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Used the release [v0.3.0](https://github.com/skills/exercise-toolkit/releases/tag/v0.3.0) of exercise toolkit for start and finish exercise workflows.

Repository README is now updated entirely based on a reusable template after the exercise is started and finished.

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
