### PR TITLE
feat: Promote agent mode content to optional step

### DIFF
--- a/.github/steps/1-preparing.md
+++ b/.github/steps/1-preparing.md
@@ -18,7 +18,8 @@ Your most common interactions will likely be:
 
 - **Inline suggestions**: As you type, Copilot uses the nearby context to suggest code directly in your editor. This will be a familiar interaction if you have used code completion tools like [Intellisense](https://code.visualstudio.com/docs/editor/intellisense), except that the completions may be entire functions.
 - **Copilot - Ask Mode**: A dedicated chat panel that lets you ask coding related questions. This will feel familiar if you have used online AI assistant chats. The big difference however, is that your project files will provide automatic context to provide tailored responses.
-- **Copilot - Edit Mode**: Similar to Copilot Chat, but less conversational. Copilot will make changes to your files to implement your request.
+- **Copilot - Edit Mode**: Similar to Ask mode, but less conversational. Copilot will make changes to your selected files to implement your request.
+- **Copilot - Agent Mode**: Copilot will run iteratively until it achieves your request. It will select context, make code changes, run terminal commands, run tools, and most importantly review its work to make adjustments.
 
 > [!TIP]
 > You can learn more about current and upcoming features in the [GitHub Copilot Features](https://docs.github.com/en/copilot/about-github-copilot/github-copilot-features) documentation. You can also select different [models](https://docs.github.com/en/github-models) and make your own [extensions](https://github.com/features/copilot/extensions), but that's for a different lesson!

--- a/.github/steps/3-copilot-edits.md
+++ b/.github/steps/3-copilot-edits.md
@@ -85,6 +85,12 @@ In our previous steps, we used features of Copilot that require more hands-on gu
 
 1. Wait a moment for Mona to check your work, provide feedback, and share the final lesson. Almost done!
 
+1. (optional) If you would like an ungraded bonus step to briefly introduce Agent mode, **add an issue comment** asking **@professortocat** about Copilot Agent mode. 🚀
+
+   ```txt
+   Hey @professortocat, Agent mode sounds pretty cool. Can you please tell me more about it?
+   ```
+
 <details>
 <summary>Having trouble? 🤷</summary><br/>
 
@@ -92,12 +98,5 @@ If you don't get feedback, here are some things to check:
 
 - Make sure your commit the changes in the `src/static/` directory to the branch `accelerate-with-copilot` and pushed/synchronized to GitHub.
 - If Mona found a mistake, simply make a correction and push your changes again. Mona will check your work as many times as needed.
-
-</details>
-
-<details>
-<summary>Bonus content? 🧐</summary><br/>
-
-> **Insider Tip:** Try adding an issue comment asking @professortocat about Copilot Agent mode. 😉
 
 </details>


### PR DESCRIPTION
This pull request includes updates to the documentation to introduce and explain the new Copilot Agent mode. It also adds an optional bonus step to engage users with this new feature.

### Documentation updates:

* [`.github/steps/1-preparing.md`](diffhunk://#diff-b23e7ecfdf7701fbb3f8583fda0b6e21e9879f24765fbfa9d721c6e41dd49229L21-R22): Updated the description of Copilot Edit Mode to clarify its similarity to Ask Mode and introduced the new Copilot Agent Mode, which iteratively runs tasks to achieve the user's request.

### Bonus step addition:

* [`.github/steps/3-copilot-edits.md`](diffhunk://#diff-ff8f072e0b226a51e4893cdb6456829340dad6f30151f26c825eb483142be37eR88-R93): Added an optional ungraded bonus step for users to ask about Copilot Agent Mode via an issue comment.
* [`.github/steps/3-copilot-edits.md`](diffhunk://#diff-ff8f072e0b226a51e4893cdb6456829340dad6f30151f26c825eb483142be37eL97-L103): Removed the previous bonus content section that suggested asking about Copilot Agent Mode, as it is now part of the new optional step.