### PR TITLE
Add usage limit reminder for GitHub Copilot free accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Get started using GitHub Copilot in less than an hour._
 - **Who is this for**: Developers at any experience level looking to accelerate their code workflow.
 - **What you'll learn**: The different ways to interact with Copilot to explain, write, debug, and develop code.
 - **What you'll build**: You will guide Copilot to update Mergington High School's extracurricular activities website.
-- **Reminder**: If you're using GitHub Copilot on a free account, usage is limited to 50 chat messages and 2,000 code completions per month. You might reach the limit during this course.
+- **Reminder**: GitHub Copilot has usage limits for free accounts — 50 chat messages and 2,000 code completions per month. These limits apply across all your Copilot usage, including throughout these courses.
 - **Prerequisites**:
   - Skills exercise: [Introduction to GitHub](https://github.com/skills/introduction-to-github)
   - Familiarity with [VS Code](https://code.visualstudio.com/)


### PR DESCRIPTION
Added a short note to the README to inform users about the monthly usage limits on GitHub Copilot for free accounts (50 chat messages and 2,000 code completions). This helps prevent confusion when users run into these limits during or across multiple Copilot courses