### PR TITLE
fix: modify step 3 grading to check for changed files instead of specific keywords

### DIFF
--- a/.github/workflows/3-copilot-edits.yml
+++ b/.github/workflows/3-copilot-edits.yml
@@ -108,9 +108,9 @@ jobs:
           vars: |
             step_number: 3
             results_table:
-              - description: "Checked if app.js for participant info"
+              - description: "Checked app.js for participant info"
                 passed: ${{ steps.check-app-js.outcome == 'success' }}
-              - description: "Checked if styles.css for participant info"
+              - description: "Checked styles.css for participant info"
                 passed: ${{ steps.check-styles-css.outcome == 'success' }}
 
       # END: Check practical exercise


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This is a long needed update to be less strict on step 3 grading where we checked for specific keywords. Users reported that copilot sometimes did the adequate changes but did not use the `participant` keyword

Test run issue: https://github.com/FidelusAleksander/skills-getting-started-with-github-copilot-step-3-grading/issues/1

### Changes
<!-- Describe the changes this pull request introduces. -->

The grading now only checks if both files were changed compared to the `main` branch

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/111

### Copilot summary

This pull request updates the workflow in `.github/workflows/3-copilot-edits.yml` to improve how it checks for modifications to `app.js` and `styles.css` as part of a practical exercise. The main changes include switching from keyphrase-based checks to verifying that the files were actually modified, and updating the step descriptions accordingly.

**Workflow improvements for file modification checks:**

* Replaced the previous keyphrase-based checks (using `skills/action-keyphrase-checker`) with explicit checks that confirm whether `src/static/app.js` and `src/static/styles.css` were modified, using `tj-actions/changed-files` and `actions/github-script`. This ensures that participants actually edit the required files.
* Updated the step descriptions in the results table to clarify that the workflow now checks if the files were modified, rather than searching for specific content.


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
