### PR TITLE
fix: replace deprecated GitHub.copilot with GitHub.copilot-chat

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,11 @@
   "name": "Python 3",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "forwardPorts": [8000],
-  "postCreateCommand": "pip install -r requirements.txt",
+  "postCreateCommand": "pip install -r lab01-getting-started-with-github-copilot/requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [
-        "GitHub.copilot",
+        "GitHub.copilot-chat",
         "ms-python.python",
         "ms-python.debugpy"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Python 3",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "forwardPorts": [8000],
-  "postCreateCommand": "pip install -r lab01-getting-started-with-github-copilot/requirements.txt",
+  "postCreateCommand": "pip install -r requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
Replaces the deprecated `GitHub.copilot` VS Code extension with `GitHub.copilot-chat` 
in `.devcontainer/devcontainer.json`.

## Problem
The `github.copilot` extension (v1.388.0) is marked as deprecated on the VS Code 
Marketplace with the warning:
> _"This extension is deprecated. Use the GitHub Copilot Chat extension instead."_

This means new dev container users would see a deprecation warning on every setup.

## Solution
Updated the extension identifier in `.devcontainer/devcontainer.json`:

```diff
- "GitHub.copilot"
+ "GitHub.copilot-chat"