### PR TITLE
fix: replace deprecated GitHub.copilot extension with GitHub.copilot-chat

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,11 @@
   "name": "Python 3",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "forwardPorts": [8000],
-  "postCreateCommand": "pip install -r requirements.txt",
+  "postCreateCommand": "pip install -r lab01-getting-started-with-github-copilot/requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [
-        "GitHub.copilot",
+        "GitHub.copilot-chat",
         "ms-python.python",
         "ms-python.debugpy"
       ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "Python 3",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "forwardPorts": [8000],
-  "postCreateCommand": "pip install -r lab01-getting-started-with-github-copilot/requirements.txt",
+  "postCreateCommand": "pip install -r requirements.txt",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary

Replace the deprecated `GitHub.copilot` VS Code extension with `GitHub.copilot-chat` in the devcontainer configuration.

## Changes

- `.devcontainer/devcontainer.json`: Updated the recommended extension from `GitHub.copilot` to `GitHub.copilot-chat`

## Reason

The `GitHub.copilot` extension ID is deprecated. `GitHub.copilot-chat` is the correct and current extension that should be used in devcontainer setups.