### PR TITLE
chore: remove mentions of @workspace

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -66,18 +66,11 @@ Let's start up our development environment, use copilot to learn a bit about the
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > @workspace Please briefly explain the structure of this project.
+   > Please briefly explain the structure of this project.
    > What should I do to run it?
    > ```
 
    > 🪧 **Note:** It is not necessary to follow Copilot's recommended instructions. We have already prepared the environment for you.
-
-   <details>
-   <summary>What is @workspace?</summary>
-
-   Great question! This is a specialized [chat participant](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/github-copilot-chat-cheat-sheet?tool=vscode#chat-participants) that will explore the project repository and try to include relevant additional context.
-
-   </details>
 
 1. Now that we know a bit more about the project, let's actually try running it! In the left sidebar, select the `Run and Debug` tab and then press the **Start Debugging** icon.
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -29,7 +29,7 @@ In short, you can think of Copilot like a very specialized coworker. To be effec
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > @workspace Students are able to register twice for an activity.
+   > #codebase Students are able to register twice for an activity.
    > Where could this bug be coming from?
    > ```
 

--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -6,7 +6,7 @@ _Congratulations, you've completed this exercise and learned a lot about GitHub 
 
 Here's a recap of the GitHub Copilot features you learned:
 
-- **Ask Mode**: Used @workspace to explore and understand your codebase
+- **Ask Mode**: Explored your codebase with Copilot
 - **Inline suggestions**: Completed code with Tab acceptance
 - **Inline Chat**: Generated code and data with Ctrl/Cmd + I
 - **Agent Mode**: Built features autonomously


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

The `@workspace` feature has been removed from VSCode. This PR removes all mentions of it.


### Changes
<!-- Describe the changes this pull request introduces. -->

This pull request updates the instructional markdown files to clarify Copilot usage and improve prompt instructions. The main changes focus on simplifying explanations, updating Copilot prompt syntax, and removing outdated references to chat participants.

**Improvements to Copilot prompt instructions:**

* Updated a prompt in `.github/steps/1-step.md` to remove the `@workspace` participant 
* Changed a prompt in `.github/steps/2-step.md` from `@workspace` to `#codebase` to reflect the current Copilot chat syntax for context-aware queries.

**Documentation and explanation updates:**

* Removed the expandable explanation of `@workspace` in `.github/steps/1-step.md` since it's no longer referenced in the prompt, streamlining the instructions.
* Updated the recap in `.github/steps/x-review.md` to generalize the description of "Ask Mode" and remove the mention of `@workspace`, making it more broadly applicable.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/174

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
