### PR TITLE
fix: add missing `GitHub-copilot-chat` extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,10 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "GitHub.copilot",
         "ms-python.python",
-        "ms-python.debugpy"
+        "ms-python.debugpy",
+        "GitHub.copilot-chat",
+        "GitHub.copilot"
       ]
     }
   }


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates the list of VS Code extensions in the `.devcontainer/devcontainer.json` file. The main change is the addition of the `GitHub.copilot-chat` extension 

Not sure what changed but right now, without the `copilot-chat` extension - they chat modes and other chat features are unavailable.

<img width="295" height="148" alt="image" src="https://github.com/user-attachments/assets/d79f4609-8d79-445a-b5e7-a4b9dbf3f227" />


I suspect that previously the `Github.Copilot` extension automatically installed the `github.copilot-chat` extension and that might have been changed. This is me guessing though




<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/166
Closes: https://github.com/skills/getting-started-with-github-copilot/issues/170
Closes: https://github.com/skills/getting-started-with-github-copilot/issues/178
Closes: https://github.com/skills/getting-started-with-github-copilot/issues/183


### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
