### PR TITLE
fix: prevent duplicate sign-ups for activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -62,6 +62,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Check if student is already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}


### PR DESCRIPTION
This pull request adds a validation step to prevent students from signing up multiple times for the same activity. Now, if a student tries to sign up for an activity they are already registered for, the system will return an error instead of adding them again.

Validation improvement:

* Added a check in `signup_for_activity` (in `src/app.py`) to raise an HTTP 400 error if the student's email is already listed as a participant for the selected activity.### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->


### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).
