### PR TITLE
Rephrase prompt for FastAPI tests planning

### DIFF
--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -38,7 +38,7 @@ Your backend still has zero test coverage. Use **Plan Agent** to create a plan, 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
    > ```prompt
-   > I want to add backend FastAPI tests in a separate tests directory.
+   > Let's plan for adding backend FastAPI tests in a separate tests directory.
    > ```
 
 1. Wait for Copilot to generate its first plan. If it asks you any questions, answer them to the best of your ability. 


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Seems like there were frequent situations where the "Plan" mode prompt was stuck on some of the tool calls - quite often `Get last terminal command`. I don't know the root cause for sure but I suspect that Copilot may sometimes not realize it is in plan mode and is trying to perform actions which are not allowed there.

Here is a sped up video of me going through the exercise as normal and after ~3min I cancelled the prompt because I ran into the reported issue. I switched the prompt a bit to imply we want to be planning and it ran without an issue

https://github.com/user-attachments/assets/1a1e316c-344a-48e7-a38e-753e950d6b63



### Changes
<!-- Describe the changes this pull request introduces. -->

Updated the plan mode prompt to be more explicit that we want to Plan the tests and not implement them immediately.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/getting-started-with-github-copilot/issues/214

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://docs.github.com/en/contributing/style-guide-and-content-model/style-guide).
