### PR TITLE
Added Feature to Check Duplicate Signups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -62,6 +62,13 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    normalized_email = email.strip().lower()
+    existing_participants = {participant.strip().lower() for participant in activity["participants"]}
+
+    # Validate student is not already signed up
+    if normalized_email in existing_participants:
+        raise HTTPException(status_code=400, detail="Student is already signed up")
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,20 @@
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from src.app import app
+
+client = TestClient(app)
+
+
+def test_student_cannot_sign_up_twice_for_same_activity():
+    activity_name = "Chess Club"
+    email = f"student-{uuid4()}@mergington.edu"
+
+    first_response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert first_response.status_code == 200
+
+    second_response = client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    assert second_response.status_code == 400
+    assert "already signed up" in second_response.json()["detail"].lower()


### PR DESCRIPTION
### Summary
Add duplicate signup protection for activities

### Changes
* Added a validation check in the FastAPI signup endpoint
* Prevents duplicate email registrations within the same activity
* Returns a clear 400 error when a student is already signed up
* Added a regression test covering duplicate signup behavior


Why?
Students were able to submit the same signup multiple times because the backend appended the email without checking whether it was already present in the activity’s participant list.